### PR TITLE
Update LogError usage to recommended overload

### DIFF
--- a/src/Muflone/Messages/MessageSubscriberBase.cs
+++ b/src/Muflone/Messages/MessageSubscriberBase.cs
@@ -130,7 +130,7 @@ public abstract class MessageSubscriberBase<TChannel>(ILoggerFactory loggerFacto
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Error while processing message of type {typeof(T).Name}, consumer {handlerConsumerInstance.GetType().Name}. The message will be discarded", ex);
+                _logger.LogError(ex, $"Error while processing message of type {typeof(T).Name}, consumer {handlerConsumerInstance.GetType().Name}. The message will be discarded");
             }
         }
 
@@ -158,7 +158,7 @@ public abstract class MessageSubscriberBase<TChannel>(ILoggerFactory loggerFacto
         }
         catch (Exception ex)
         {
-            _logger.LogError($"Error while deserializing message of type {typeof(T).Name}. The message will be discarded", ex);
+            _logger.LogError(ex, $"Error while deserializing message of type {typeof(T).Name}. The message will be discarded");
         }
 
         return null;


### PR DESCRIPTION
Refactored _logger.LogError calls to pass the exception as the first argument and the message as the second, following .NET structured logging best practices for improved clarity and consistency.